### PR TITLE
Replace `--strict` command-line option with `--strict-markers`

### DIFF
--- a/tests/test_pytest_pydocstyle.py
+++ b/tests/test_pytest_pydocstyle.py
@@ -94,7 +94,7 @@ def test_strict(testdir):
             pass
     ''')
     p = p.write(p.read() + "\n")
-    result = testdir.runpytest('--strict', '--pydocstyle')
+    result = testdir.runpytest('--strict-markers', '--pydocstyle')
     result.assert_outcomes(passed=1)
 
 


### PR DESCRIPTION
https://docs.pytest.org/en/latest/deprecations.html#the-strict-command-line-option
```
$ pytest -s tests
../../../../../../../../../Users/henry/.pyenv/versions/3.9.10/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/_pytest/config/__init__.py:1195
  /Users/henry/.pyenv/versions/3.9.10/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/_pytest/config/__init__.py:1195: PytestRemovedIn8Warning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(
```